### PR TITLE
Add Vue as peer dependency and use .js file 依存

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   ],
   "engines": {
     "node": ">=6"
+  },
+  "peerDependencies": {
+    "vue": "~2.0"
   }
 }

--- a/src/ProxyComponent.js
+++ b/src/ProxyComponent.js
@@ -1,7 +1,4 @@
-<script>
-import Vue from 'vue';
-
-export default Vue.extend({
+export default {
   name: 'ProxyComponent',
   props: {
     tag: {
@@ -19,5 +16,4 @@ export default Vue.extend({
   beforeDestroy() {
     this.$el.remove();
   },
-});
-</script>
+};


### PR DESCRIPTION
`import Vue`する必要はないです。Vueコンポーネントなので、すでにVueがインストールしたはずです。なので、VueをPeer Dependencyにしました（ユーザーは自分でインストールするDependency（依存？）。

Vueコンポーネントは`.vue`ファイルじゃなくても大丈夫です。必要なことが２つ：

1. `name`
2. `template`か`render`関数。

